### PR TITLE
moved getJsonFromRecordSet into db-request.ts

### DIFF
--- a/api/src/db/db-request.ts
+++ b/api/src/db/db-request.ts
@@ -1,7 +1,7 @@
 import {Either, Left, Option, Right} from "funfix-core";
 import {List, Set} from "immutable";
 import {ConnectionPool, IRecordSet} from "mssql";
-import {EitherUtils, getJsonFromRecordSet, JsonSerializer} from "@kashw2/lib-util";
+import {EitherUtils, JsonSerializer} from "@kashw2/lib-util";
 import {Database} from "./database";
 
 export class DbRequest {
@@ -11,6 +11,25 @@ export class DbRequest {
     }
 
     private connection: Promise<ConnectionPool>;
+
+
+    /**
+     * getJsonFromRecordSet()
+     *
+     * Given a Recordset probably returned from a Db query/procedure
+     * Return an object that doesn't have to be manipulated to access data correctly
+     * Function will probably evolve overtime, this is it in it's bare-bones state
+     *
+     */
+    private getJsonFromRecordSet(rs: any): Either<string, IRecordSet<any>> {
+        if (!rs || rs === "{}" || rs === []) {
+            return Left("Database returned empty resultset");
+        }
+        if (typeof rs[0][''] === "string") {
+            return Right(JSON.parse(rs[0]['']));
+        }
+        return Right(rs[0]);
+    }
 
     async sendRequest(
         procedure: string,
@@ -25,7 +44,7 @@ export class DbRequest {
             console.error(`Error running: ${procedure} ${params.join(",").trim()}`);
             return Left(`Error running: ${procedure} ${params.join(",").trim()}`);
         }
-        return getJsonFromRecordSet(result.recordset);
+        return this.getJsonFromRecordSet(result.recordset);
     }
 
     async sendRequestList(
@@ -38,7 +57,7 @@ export class DbRequest {
         if (Option.of(result.recordset[0]).isEmpty()) {
             return Right(List());
         }
-        return getJsonFromRecordSet(result.recordset)
+        return this.getJsonFromRecordSet(result.recordset)
             .map((x: IRecordSet<any>) => List(x));
     }
 
@@ -74,7 +93,7 @@ export class DbRequest {
             console.error(`Error running: ${procedure} ${params.join(",").trim()}`);
             return Right(Set());
         }
-        return getJsonFromRecordSet(result.recordset)
+        return this.getJsonFromRecordSet(result.recordset)
             .map((x: IRecordSet<any>) => Set(x));
     }
 

--- a/libs/util/package.json
+++ b/libs/util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kashw2/lib-util",
-  "version": "3.0.3",
+  "version": "4.0.0",
   "description": "Fleet of the Faithful Knights Utility Library'",
   "main": "./dist/main/index.js",
   "typings": "./dist/main/index.d.ts",

--- a/libs/util/src/object-utils.ts
+++ b/libs/util/src/object-utils.ts
@@ -7,10 +7,6 @@ export function parseString(s: unknown): Option<string> {
     return Option.of(s)
         .flatMap(v => {
             switch (typeof v) {
-                case 'bigint':
-                    return Option.of(v)
-                        .filter(x => isNaN(Number(x)) && isFinite(Number(x)))
-                        .map(x => x.toString());
                 case 'number':
                     return Option.of(v)
                         .filter(x => !isNaN(x) && isFinite(x))
@@ -76,8 +72,6 @@ export function parseBoolean(v: unknown): Option<boolean> {
             switch (typeof b) {
                 case 'number':
                     return Option.of(b).contains(1) ? Option.of(true) : Option.of(false);
-                case 'bigint':
-                    return Option.of(Number(b)).contains(1) ? Some(true) : Some(false);
                 case 'string':
                     return Option.of(b).exists(x => x === 'true' || x === 'false')
                         ? Option.of(b).contains('true') ? Some(true) : Some(false)
@@ -101,8 +95,6 @@ export function parseNumber(v: unknown): Option<number> {
                 case 'number':
                     return Option.of(n)
                         .filter(x => !isNaN(x));
-                case 'bigint':
-                    return Option.of(Number(n));
                 case 'boolean':
                     return Option.of(n).contains(true) ? Some(1) : Some(0);
                 default:

--- a/libs/util/src/object-utils.ts
+++ b/libs/util/src/object-utils.ts
@@ -1,26 +1,7 @@
-import {Either, Left, None, Option, Right, Some} from 'funfix-core';
+import {None, Option, Some} from 'funfix-core';
 import moment from 'moment';
 import {List, Set} from 'immutable';
 import {JsonSerializer} from './json-serializer';
-import {IRecordSet} from "mssql";
-
-/**
- * getJsonFromRecordSet()
- *
- * Given a Recordset probably returned from a Db query/procedure
- * Return an object that doesn't have to be manipulated to access data correctly
- * Function will probably evolve overtime, this is it in it's barebones state
- *
- */
-export function getJsonFromRecordSet(rs: any): Either<string, IRecordSet<any>> {
-    if (!rs || rs === "{}" || rs === []) {
-        return Left("Database returned empty resultset");
-    }
-    if (typeof rs[0][''] === "string") {
-        return Right(JSON.parse(rs[0]['']));
-    }
-    return Right(rs[0]);
-}
 
 export function parseString(s: unknown): Option<string> {
     return Option.of(s)

--- a/libs/util/tests/object-utils.spec.ts
+++ b/libs/util/tests/object-utils.spec.ts
@@ -1,5 +1,5 @@
 import test from "ava";
-import {parseString, parseNumber, parseBoolean, getJsonFromRecordSet} from "../src";
+import {parseString, parseNumber, parseBoolean} from "../src";
 import {None, Right, Some} from "funfix-core";
 
 test('parseString should succeed with a string>', t => {
@@ -60,9 +60,4 @@ test('parseBoolean should succeed with string', t => {
 test('parseBoolean should fail with default', t => {
     const result = parseBoolean(new Date());
     t.deepEqual(result, None);
-});
-
-test('getJsonFromRecordSet should parse from first item', t => {
-    const result = getJsonFromRecordSet(["Hello World"]);
-    t.deepEqual(result, Right('Hello World'));
 });

--- a/libs/util/tests/object-utils.spec.ts
+++ b/libs/util/tests/object-utils.spec.ts
@@ -1,6 +1,6 @@
 import test from "ava";
-import {parseString, parseNumber, parseBoolean} from "../src";
-import {None, Right, Some} from "funfix-core";
+import {parseBoolean, parseNumber, parseString} from "../src";
+import {None, Some} from "funfix-core";
 
 test('parseString should succeed with a string>', t => {
     const result = parseString('Hello World');


### PR DESCRIPTION
Signed-off-by: kashw2 <supra4keanu@hotmail.com>

## Checklist

Please complete this checklist before requesting review.

Your pull request may not be accepted if you have not completed the following:

- [x] Linted your changes
- [x] Tested your changes
- [x] Rebased your branch

## Type

Please select the type of change your PR proposes

- [ ] Feature
- [x] Enhancement
- [ ] Bug Fix
- [ ] Documentation Changes
- [ ] CI/CD Changes
- [ ] Other (Please Describe)

## Description

BREAKING CHANGES:
- Moved getJsonFromRecordSet out of lib-util and into db-request in the api directory as it is only used there
- Removed explicit support for bigint in object-utils

FEATURES:

FIXES:

TEST:
- Removed getJsonFromRecordSet tests

BUILD:
- Released lib-util 4.0.0